### PR TITLE
CMakeLists.txt: Set project LANGUAGES to C

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8.12...3.20)
 
-project(enet)
+project(enet LANGUAGES C)
 
 # The "configure" step.
 include(CheckFunctionExists)


### PR DESCRIPTION
Not specifying `LANGUAGES` makes CMake look for a C++ compiler and the configure step fails if it doesn't find it. We only use C, so let's avoid that check.
